### PR TITLE
bugfix: code completion freeze on non-existing entry

### DIFF
--- a/src/main/scala/de/sciss/scalainterpreter/actions/CompletionAction.scala
+++ b/src/main/scala/de/sciss/scalainterpreter/actions/CompletionAction.scala
@@ -149,36 +149,36 @@ object CompletionAction {
     }
 
     private def keyPressed(e: KeyPressed): Unit = {
-      val i  = ggList.selection.indices.head
-      val ch = e.peer.getKeyChar
-      e.key match {
-        case Key.Escape => finish(None)
+      ggList.selection.indices.headOption.map { i => 
+      	val ch = e.peer.getKeyChar
+      	e.key match {
+      	  case Key.Escape => finish(None)
 
-        case Key.Down if i < ggList.model.size - 1 =>
-          val i1 = i + 1
-          selectedIndex = i1
-          ggList.ensureIndexIsVisible(i1)
+       	  case Key.Down if i < ggList.model.size - 1 =>
+            val i1 = i + 1
+            selectedIndex = i1
+            ggList.ensureIndexIsVisible(i1)
 
-        case Key.Up if i > 0 =>
-          val i1 = i - 1
-          selectedIndex = i1
-          ggList.ensureIndexIsVisible(i1)
+          case Key.Up if i > 0 =>
+            val i1 = i - 1
+            selectedIndex = i1
+            ggList.ensureIndexIsVisible(i1)
 
-        case _ if escapeChars.indexOf(ch) >= 0 =>
-          val result0 = if (selectedIndex >= 0) {
-            selectedItem
-          } else {
-            ggText.text
-          }
-          val result = if (ch == '\n') result0 else {
-            result0 + (if (ch == '\t') ' ' else ch)
-          }
-          finish(Some(result))
+          case _ if escapeChars.indexOf(ch) >= 0 =>
+            val result0 = if (selectedIndex >= 0) {
+              selectedItem
+            } else {
+              ggText.text
+            }
+            val result = if (ch == '\n') result0 else {
+              result0 + (if (ch == '\t') ' ' else ch)
+            }
+            finish(Some(result))
 
-        case _ =>
+          case _ =>
+        }
       }
     }
-
     private def selectedItem  = ggList.selection.items  .headOption.orNull
     private def selectedIndex = ggList.selection.indices.headOption.getOrElse(-1)
     private def selectedIndex_=(i: Int): Unit = ggList.selectIndices(i)


### PR DESCRIPTION

![completionbug](https://cloud.githubusercontent.com/assets/10944449/6349927/ccff9e5e-bc2f-11e4-9a1c-ea195e0db1c2.png)
This is a very basic fix to a bug I encounter on code completion. When no entry matches the typed prefix, the completion dialog freezes and with it the entire application.  For my current use, I duplicated the CompletionAction file in my user project and I implemented the fix there. I thought it would be simpler to just add the fix here.  Cheers.